### PR TITLE
Set Profile Button To Current User

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -48,7 +48,7 @@ const Header = (props: HeaderProps) => {
               <DropdownMenuItem
                 onClick={() =>
                   window.open(
-                    "https://sso.gauchoracing.com/users/348220961155448833/edit",
+                    `https://sso.gauchoracing.com/users/${currentUser.id}/edit`,
                     "_blank",
                   )
                 }


### PR DESCRIPTION
Resolves #1

Changes the profile button from being hard coded to BK's account to the current users

Follows what is done in [Mapache `Header.tsx`](https://github.com/Gaucho-Racing/Mapache/blob/main/dashboard/src/components/Header.tsx)